### PR TITLE
added joker configuration to forward unknown 'user'

### DIFF
--- a/plugins/rcpt_to.alias_forward.js
+++ b/plugins/rcpt_to.alias_forward.js
@@ -10,9 +10,10 @@ exports.alias_forward = function(next, connection, params) {
   var
     plugin = this,
     aliases = this.config.get('rcpt_to.alias_forward', 'json') || {},
+    rcpt = params[0],
     list;
-  if(aliases[params[0].host] && aliases[params[0].host][params[0].user]) {
-    list = aliases[params[0].host][params[0].user];
+  if(aliases[rcpt.host] && (aliases[rcpt.host][rcpt.user] || aliases[rcpt.host]["*"])) {
+    list = aliases[rcpt.host][rcpt.user] || aliases[rcpt.host]["*"];
     if(!util.isArray(list))
       list = [ list ];
     connection.transaction.rcpt_to.pop();


### PR DESCRIPTION
I added a joker configuration. Declaring an "*" alias will forward any email not matching any other alias.
